### PR TITLE
URL Cleanup

### DIFF
--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/build.gradle
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/pom.xml
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-device-delegating-view-resolver-jc-thymeleaf</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -145,7 +145,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/build.gradle
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/pom.xml
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-device-delegating-view-resolver-jc</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/java-configuration/lite-device-resolver-jc/build.gradle
+++ b/archive/java-configuration/lite-device-resolver-jc/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/java-configuration/lite-device-resolver-jc/pom.xml
+++ b/archive/java-configuration/lite-device-resolver-jc/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-device-resolver-jc</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/java-configuration/lite-site-preference-handler-jc/build.gradle
+++ b/archive/java-configuration/lite-site-preference-handler-jc/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/java-configuration/lite-site-preference-handler-jc/pom.xml
+++ b/archive/java-configuration/lite-site-preference-handler-jc/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-site-preference-handler-jc</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/build.gradle
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/pom.xml
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-site-switcher-handler-jc-mdot</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/build.gradle
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/pom.xml
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-site-switcher-handler-jc-urlpath</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/build.gradle
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/pom.xml
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-device-delegating-view-resolver-xml</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/xml-configuration/lite-device-resolver-xml/build.gradle
+++ b/archive/xml-configuration/lite-device-resolver-xml/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 task wrapper(type: Wrapper) {

--- a/archive/xml-configuration/lite-device-resolver-xml/pom.xml
+++ b/archive/xml-configuration/lite-device-resolver-xml/pom.xml
@@ -8,12 +8,12 @@
 	<version>0.1.0</version>
 	<packaging>war</packaging>
 	<name>lite-device-resolver-xml</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>Demonstration of Spring Mobile's lightweight server-side device detection and site switching functionality</description>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>
@@ -138,7 +138,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/archive/xml-configuration/thorax-lumbar-client/build.gradle
+++ b/archive/xml-configuration/thorax-lumbar-client/build.gradle
@@ -57,10 +57,10 @@ dependencies {
 }
 
 repositories {
-	mavenRepo urls: "http://maven.springframework.org/release"
-	mavenRepo urls: "http://maven.springframework.org/milestone"
-	mavenRepo urls: "http://maven.springframework.org/snapshot"
-	mavenRepo urls: "http://download.java.net/maven/2"
+	mavenRepo urls: "https://maven.springframework.org/release"
+	mavenRepo urls: "https://maven.springframework.org/milestone"
+	mavenRepo urls: "https://maven.springframework.org/snapshot"
+	mavenRepo urls: "https://download.java.net/maven/2"
 	mavenCentral()
 }
 
@@ -94,7 +94,7 @@ buildscript {
     repositories {
         add(new org.apache.ivy.plugins.resolver.URLResolver()) {
             name = "GitHub"
-            addArtifactPattern "http://cloud.github.com/downloads/[organisation]/[module]/[module]-[revision].[ext]"
+            addArtifactPattern "https://cloud.github.com/downloads/[organisation]/[module]/[module]-[revision].[ext]"
         }
     }
 

--- a/lite-device-delegating-view-resolver-jsp/build.gradle
+++ b/lite-device-delegating-view-resolver-jsp/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.7.RELEASE")
@@ -23,7 +23,7 @@ jar {
 }
 
 repositories {
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 dependencies {

--- a/lite-device-delegating-view-resolver-jsp/pom.xml
+++ b/lite-device-delegating-view-resolver-jsp/pom.xml
@@ -59,14 +59,14 @@
 	<repositories>
 		<repository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/plugins-release</url>
+			<url>https://repo.spring.io/plugins-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/lite-device-delegating-view-resolver/build.gradle
+++ b/lite-device-delegating-view-resolver/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
-		maven { url "http://repo.spring.io/libs-milestone" }
+		maven { url "https://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/libs-milestone" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:2.0.0.M6")
@@ -28,9 +28,9 @@ jar {
 }
 
 repositories {
-	maven { url "http://repo.spring.io/libs-release" }
-	maven { url "http://repo.spring.io/libs-milestone" }
-	maven { url "http://repo.spring.io/libs-snapshot" }
+	maven { url "https://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-milestone" }
+	maven { url "https://repo.spring.io/libs-snapshot" }
 }
 
 dependencies {

--- a/lite-device-delegating-view-resolver/pom.xml
+++ b/lite-device-delegating-view-resolver/pom.xml
@@ -54,15 +54,15 @@
 	<repositories>
 		<repository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 		<repository>
 			<id>spring-milestones</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 		<repository>
 			<id>spring-snapshots</id>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -72,7 +72,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/plugins-release</url>
+			<url>https://repo.spring.io/plugins-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/lite-device-resolver/build.gradle
+++ b/lite-device-resolver/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
-		maven { url "http://repo.spring.io/libs-milestone" }
+		maven { url "https://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/libs-milestone" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:2.0.0.M6")
@@ -27,8 +27,8 @@ jar {
 }
 
 repositories {
-	maven { url "http://repo.spring.io/libs-release" }
-	maven { url "http://repo.spring.io/libs-milestone" }
+	maven { url "https://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-milestone" }
 }
 
 dependencies {

--- a/lite-device-resolver/pom.xml
+++ b/lite-device-resolver/pom.xml
@@ -68,7 +68,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/plugins-release</url>
+			<url>https://repo.spring.io/plugins-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/lite-site-preference-handler-jsp/build.gradle
+++ b/lite-site-preference-handler-jsp/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.7.RELEASE")
@@ -23,7 +23,7 @@ jar {
 }
 
 repositories {
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 dependencies {

--- a/lite-site-preference-handler-jsp/pom.xml
+++ b/lite-site-preference-handler-jsp/pom.xml
@@ -59,22 +59,22 @@
 	<repositories>
 		<repository>
 			<id>spring-release-staging</id>
-			<url>http://repo.spring.io/libs-staging-local</url>
+			<url>https://repo.spring.io/libs-staging-local</url>
 		</repository>
 		<repository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-release-staging</id>
-			<url>http://repo.spring.io/libs-staging-local</url>
+			<url>https://repo.spring.io/libs-staging-local</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/plugins-release</url>
+			<url>https://repo.spring.io/plugins-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://cloud.github.com/downloads/ (UnknownHostException) migrated to:  
  https://cloud.github.com/downloads/ ([https](https://cloud.github.com/downloads/) result UnknownHostException).
* http://download.java.net/maven/2 (301) migrated to:  
  https://download.java.net/maven/2 ([https](https://download.java.net/maven/2) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.spring.io migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/libs-staging-local migrated to:  
  https://repo.spring.io/libs-staging-local ([https](https://repo.spring.io/libs-staging-local) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance