### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ There are several sample applications that illustrate Java or XML based configur
 [lite-site-preference-handler-jsp]: ./lite-site-preference-handler-jsp
 [Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: CONTRIBUTING.md
-[Apache license]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache license]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/README.md
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/README.md
@@ -48,4 +48,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/AboutController.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc-thymeleaf/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/README.md
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/README.md
@@ -48,4 +48,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/AboutController.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/java-configuration/lite-device-delegating-view-resolver-jc/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-resolver-jc/README.md
+++ b/archive/java-configuration/lite-device-resolver-jc/README.md
@@ -46,4 +46,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-device-resolver-jc/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/java-configuration/lite-device-resolver-jc/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
+++ b/archive/java-configuration/lite-device-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
+++ b/archive/java-configuration/lite-device-resolver-jc/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-resolver-jc/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/java-configuration/lite-device-resolver-jc/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-device-resolver-jc/src/test/java/org/springframework/showcases/lite/StubDevice.java
+++ b/archive/java-configuration/lite-device-resolver-jc/src/test/java/org/springframework/showcases/lite/StubDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-preference-handler-jc/README.md
+++ b/archive/java-configuration/lite-site-preference-handler-jc/README.md
@@ -47,4 +47,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-site-preference-handler-jc/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/java-configuration/lite-site-preference-handler-jc/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-preference-handler-jc/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
+++ b/archive/java-configuration/lite-site-preference-handler-jc/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-preference-handler-jc/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
+++ b/archive/java-configuration/lite-site-preference-handler-jc/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-preference-handler-jc/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/java-configuration/lite-site-preference-handler-jc/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/README.md
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/README.md
@@ -50,4 +50,4 @@ A [Spring Mobile] sample application demonstrating the [`mDot`] Site Switcher st
 
 [`mDot`]: https://docs.spring.io/spring-mobile/docs/1.1.x/reference/html/device.html#site-switcher-handler-interceptor-mdot
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/AboutController.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-mdot/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/README.md
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/README.md
@@ -47,4 +47,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 [`urlPath`]: https://docs.spring.io/spring-mobile/docs/1.1.x/reference/html/device.html#site-switcher-handler-interceptor-urlpath
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/AboutController.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/main/java/org/springframework/showcases/lite/config/WebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/java-configuration/lite-site-switcher-handler-jc-urlpath/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/README.md
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/README.md
@@ -48,4 +48,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/main/java/org/springframework/showcases/lite/AboutController.java
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/main/java/org/springframework/showcases/lite/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/test/java/org/springframework/showcases/lite/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/xml-configuration/lite-device-delegating-view-resolver-xml/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-resolver-xml/README.md
+++ b/archive/xml-configuration/lite-device-resolver-xml/README.md
@@ -46,4 +46,4 @@ A [Spring Mobile] sample application demonstrating many of the capabilities of t
 
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/archive/xml-configuration/lite-device-resolver-xml/src/main/java/org/springframework/showcases/lite/HomeController.java
+++ b/archive/xml-configuration/lite-device-resolver-xml/src/main/java/org/springframework/showcases/lite/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-resolver-xml/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
+++ b/archive/xml-configuration/lite-device-resolver-xml/src/test/java/org/springframework/showcases/lite/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/lite-device-resolver-xml/src/test/java/org/springframework/showcases/lite/StubDevice.java
+++ b/archive/xml-configuration/lite-device-resolver-xml/src/test/java/org/springframework/showcases/lite/StubDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/archive/xml-configuration/thorax-lumbar-client/README.md
+++ b/archive/xml-configuration/thorax-lumbar-client/README.md
@@ -69,4 +69,4 @@ In order to build this application, you must have Lumbar installed. You do not n
 [Backbone]: https://backbonejs.org/
 [Gradle]: https://www.gradle.org/
 [app-url]: http://localhost:8080/thorax-client
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/lite-device-delegating-view-resolver-jsp/README.md
+++ b/lite-device-delegating-view-resolver-jsp/README.md
@@ -59,4 +59,4 @@ spring.mobile.devicedelegatingviewresolver.enabled: true
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
 [Spring Boot]: https://projects.spring.io/spring-boot
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/lite-device-delegating-view-resolver-jsp/src/main/java/showcases/AboutController.java
+++ b/lite-device-delegating-view-resolver-jsp/src/main/java/showcases/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver-jsp/src/main/java/showcases/Application.java
+++ b/lite-device-delegating-view-resolver-jsp/src/main/java/showcases/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver-jsp/src/main/java/showcases/HomeController.java
+++ b/lite-device-delegating-view-resolver-jsp/src/main/java/showcases/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver-jsp/src/test/java/showcases/AboutControllerTest.java
+++ b/lite-device-delegating-view-resolver-jsp/src/test/java/showcases/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver-jsp/src/test/java/showcases/HomeControllerTest.java
+++ b/lite-device-delegating-view-resolver-jsp/src/test/java/showcases/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver/README.md
+++ b/lite-device-delegating-view-resolver/README.md
@@ -59,4 +59,4 @@ spring.mobile.devicedelegatingviewresolver.enabled: true
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
 [Spring Boot]: https://projects.spring.io/spring-boot
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/lite-device-delegating-view-resolver/src/main/java/showcases/AboutController.java
+++ b/lite-device-delegating-view-resolver/src/main/java/showcases/AboutController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver/src/main/java/showcases/Application.java
+++ b/lite-device-delegating-view-resolver/src/main/java/showcases/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver/src/main/java/showcases/HomeController.java
+++ b/lite-device-delegating-view-resolver/src/main/java/showcases/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver/src/test/java/showcases/AboutControllerTest.java
+++ b/lite-device-delegating-view-resolver/src/test/java/showcases/AboutControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-delegating-view-resolver/src/test/java/showcases/HomeControllerTest.java
+++ b/lite-device-delegating-view-resolver/src/test/java/showcases/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-resolver/README.md
+++ b/lite-device-resolver/README.md
@@ -44,4 +44,4 @@ A [Spring Mobile] sample application demonstrating the Device Resolver capabilit
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
 [Spring Boot]: https://projects.spring.io/spring-boot
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/lite-device-resolver/src/main/java/showcases/Application.java
+++ b/lite-device-resolver/src/main/java/showcases/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-resolver/src/main/java/showcases/HomeController.java
+++ b/lite-device-resolver/src/main/java/showcases/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-device-resolver/src/test/java/showcases/HomeControllerTest.java
+++ b/lite-device-resolver/src/test/java/showcases/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-site-preference-handler-jsp/README.md
+++ b/lite-site-preference-handler-jsp/README.md
@@ -57,4 +57,4 @@ spring.mobile.sitepreference.enabled: false
 
 [Spring Mobile]: https://projects.spring.io/spring-mobile
 [Spring Boot]: https://projects.spring.io/spring-boot
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/lite-site-preference-handler-jsp/src/main/java/showcases/Application.java
+++ b/lite-site-preference-handler-jsp/src/main/java/showcases/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-site-preference-handler-jsp/src/main/java/showcases/HomeController.java
+++ b/lite-site-preference-handler-jsp/src/main/java/showcases/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lite-site-preference-handler-jsp/src/test/java/showcases/HomeControllerTest.java
+++ b/lite-site-preference-handler-jsp/src/test/java/showcases/HomeControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 71 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).